### PR TITLE
Special-case for varData generation

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -61,6 +61,11 @@ class LibRsDef
             indent(libRs, 0, "#![allow(clippy::uninlined_format_args)]\n");
             indent(libRs, 0, "#![allow(clippy::unnecessary_cast)]\n");
             indent(libRs, 0, "#![allow(non_camel_case_types)]\n");
+            // FIXME: we should probably not allow ambiguous glob reexports,
+            // but this was in the generated code prior to this change,
+            // so leaving it as-is for now.  Not sure where it got to;
+            // JAR file in core repo built off a different commit than the one in config.toml perhaps?
+            indent(libRs, 0, "#![allow(ambiguous_glob_reexports)]\n");
             indent(libRs, 0, "use ::core::{convert::TryInto};\n\n");
 
             final ArrayList<String> modules = new ArrayList<>();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -576,7 +576,7 @@ public class RustGenerator implements CodeGenerator
         }
         else
         {
-            indent(sb, level, "pub fn %s(self) -> %2$s<Self> {\n",
+            indent(sb, level, "pub fn %s(self) -> Option<%2$s<Self>> {\n",
                 decoderName,
                 decoderTypeName);
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1269,9 +1269,15 @@ public class RustGenerator implements CodeGenerator
     {
         for (final List<Token> tokens : ir.types())
         {
-            if (!tokens.isEmpty() && tokens.get(0).signal() == Signal.BEGIN_COMPOSITE)
+            if (!tokens.isEmpty())
             {
-                generateComposite(tokens, outputManager);
+                final Token firstToken = tokens.get(0);
+                // Special-case out varDataEncoding as its size can't be known at compile-time
+                // and it's inlined into its parent:
+                if (firstToken.signal() == Signal.BEGIN_COMPOSITE && !firstToken.name().equals("varDataEncoding"))
+                {
+                    generateComposite(tokens, outputManager);
+                }
             }
         }
     }


### PR DESCRIPTION
Also updated:
- Composite Decoder generation
- added a clippy lint that appears in the previous codegen from `core` but is missing in this repo